### PR TITLE
feat: interpret q parameter as query

### DIFF
--- a/static/bundle.js
+++ b/static/bundle.js
@@ -1,7 +1,15 @@
+function setQueryParam(s) {
+    let params = URLSearchParams(window.location.search)
+    params.set("q", s);
+    var newRelativePathQuery = window.location.pathname + '?' + params.toString();
+    history.pushState(null, '', newRelativePathQuery);
+}
+
 function searchTriggered() {
     let searchbox = document.getElementById("searchbox");
     let query = searchbox.value
-    searchFor(query);
+    searchFor(query)
+    setQueryParam(query)
     passQueryToResultpage(query)
 }
 

--- a/static/view.js
+++ b/static/view.js
@@ -7,11 +7,19 @@ window.addEventListener("message", receiveMessage, false);
 function receiveMessage(event) {
     app.resultPageHeight = event.data
 }
-searchbox = document.getElementById('searchbox')
+
+const searchbox = document.getElementById('searchbox')
 if (searchbox != null) {
     searchbox.onkeydown = function (event) {
         if (event.keyCode == 13) {
             searchTriggered()
         }
     }
+}
+
+const urlParams = new URLSearchParams(window.location.search);
+const query = urlParams.get('q');
+if (query != null) {
+    searchbox.value = query
+    searchTriggered()
 }

--- a/website/bundle.js
+++ b/website/bundle.js
@@ -186,9 +186,17 @@ async function checkIfIpfsGateway(gatewayURL) {
     }
 }
 
+function setQueryParam(s) {
+    let params = URLSearchParams(window.location.search)
+    params.set("q", s);
+    var newRelativePathQuery = window.location.pathname + '?' + params.toString();
+    history.pushState(null, '', newRelativePathQuery);
+}
+
 function searchTriggered() {
     let searchbox = document.getElementById("searchbox");
     let querytokens = searchbox.value.split(" ");
+    passQueryToResultpage(searchbox.value)
     querytokens = querytokens.map(querytoken => {
         return stemmer(querytoken);
     });

--- a/website/view.js
+++ b/website/view.js
@@ -7,11 +7,19 @@ window.addEventListener("message", receiveMessage, false);
 function receiveMessage(event) {
     app.resultPageHeight = event.data
 }
-searchbox = document.getElementById('searchbox')
+
+const searchbox = document.getElementById('searchbox')
 if (searchbox != null) {
     searchbox.onkeydown = function (event) {
         if (event.keyCode == 13) {
             searchTriggered()
         }
     }
+}
+
+const urlParams = new URLSearchParams(window.location.search);
+const query = urlParams.get('q');
+if (query != null) {
+    searchbox.value = query
+    searchTriggered()
 }


### PR DESCRIPTION
It would be desirable to add a parameter to the uri in `searchTriggered()` too. I plan to do that a bit later, maybe in the same PR.

Closes #6.