### PR TITLE
If a hash is given in the URL, search for it

### DIFF
--- a/static/bundle.js
+++ b/static/bundle.js
@@ -1,6 +1,9 @@
 function searchTriggered() {
     let searchbox = document.getElementById("searchbox");
     let query = searchbox.value
+    let url = new URL(window.location);
+    url.hash = query;
+    window.history.pushState({}, document.title, url);
     searchFor(query);
     passQueryToResultpage(query)
 }

--- a/website/view.js
+++ b/website/view.js
@@ -15,3 +15,10 @@ if (searchbox != null) {
         }
     }
 }
+
+// If the URL has a hash (e.g. #ubuntu iso), search for it.
+if (window.location.hash) {
+    // `substr(1)` to trim off the leading `#`, `decodeURIComponent` to handle things like `%20` for ` `.
+    searchbox.value = decodeURIComponent(window.location.hash.substr(1));
+    searchTriggered();
+}


### PR DESCRIPTION
Makes `https://torrent-paradise.ml/#ubuntu%20iso` automatically open a search for `ubuntu iso`.

Similarly, when you search for `ubuntu iso`, updates the URL to `https://torrent-paradise.ml/#ubuntu%20iso`.

This change enables things like adding torrent-paradise as a [custom search engine](https://superuser.com/a/7374) in Firefox or Chrome.

This pull request is provided "as-is" -- you're welcome to modify it if you want, but I won't do any additional work on it.