### PR TITLE
Replace Bayfiles with MultiUp

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ The torrent collection is a mashup of the (now no longer provided) TPB dumps, my
 
 The easiest way to get your own site up and running is to start with my .csv dump. It should be easy to import into any kind of system. It contains seed/leech counts too (!). If I were to import it, I'd modify import-magnetico-db.
 
-__Torrent Paradise csv dump__: [MEGA](https://mega.nz/file/MIcgyBiL#Ptlna9zvHqo_YpHEbVHt3o2L_EYX8cGI-n8y1OHH_YA) [BayFiles](https://bayfiles.com/p1b9UfBbxd/dump.csv_xz) [IPFS](https://cloudflare-ipfs.com/ipfs/QmcsjpRsLkSojdJ19PpTYoevP8ZdeCqmtEvjqa2R28rxWs)
+__Torrent Paradise csv dump__: [MEGA](https://mega.nz/file/MIcgyBiL#Ptlna9zvHqo_YpHEbVHt3o2L_EYX8cGI-n8y1OHH_YA) [MultiUp](https://www.multiup.org/download/a28f97be34fd62ef5c4edc50f9c5c9e0/nextgenpostgres20220113-db.dump) [IPFS](https://cloudflare-ipfs.com/ipfs/QmcsjpRsLkSojdJ19PpTYoevP8ZdeCqmtEvjqa2R28rxWs)
 
-old dump (2020): [MEGA](https://mega.nz/file/IFcTBCKZ#v3OCPNeja4lRC5baccVDeTaQUE150wqqGyS6A1mxglc) 
+old dump (2020): [MEGA](https://mega.nz/file/IFcTBCKZ#v3OCPNeja4lRC5baccVDeTaQUE150wqqGyS6A1mxglc) [MultiUp](https://www.multiup.org/download/4d443c19ac3c01e44b4f1678a1364f04/torrentparadise-dump-200720.csv.xz)
 
-__Torrent Paradise pg_dump__ (database): [MEGA](https://mega.nz/file/AElUWC5L#fKS5fV0CpBSBq-4khi35BntYvHuI1EBwOavsEBT-5sY) [BayFiles](https://bayfiles.com/B576U1B6x7/nextgenpostgres20220113-db_dump) 
+__Torrent Paradise pg_dump__ (database): [MEGA](https://mega.nz/file/AElUWC5L#fKS5fV0CpBSBq-4khi35BntYvHuI1EBwOavsEBT-5sY) [MultiUp](https://www.multiup.org/download/99b5fe309cbe5f936798bc4f0d3d8eb9/torrentparadise-dump-220117.csv.xz) 
 
 # Usage
 


### PR DESCRIPTION
![msedge_20230413_w87tyq9kP8](https://user-images.githubusercontent.com/7843719/229908279-105725e3-cac0-4f84-a6ef-d943a464e666.png)

I replaced the dead Bayfiles mirrors with a multi-upload file sharing site that uploads onto multiple sites at once.